### PR TITLE
Add Live Coding Manual toggle

### DIFF
--- a/BitBeatSynth/ContentView.swift
+++ b/BitBeatSynth/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var a: Float = 3
     @State private var b: Float = 11
     @State private var activePanel: SidebarMenu.Panel? = nil
+    @State private var showLiveManual = false
 
 
     var body: some View {
@@ -91,9 +92,14 @@ struct ContentView: View {
                 } else {
                     VStack(spacing: 8) {
                         ZStack {
-                            WaveformView(samples: audio.waveformBuffer)
-                                .opacity(0.25) // ✅ make it subtle
-                                .edgesIgnoringSafeArea(.all)
+                            if showLiveManual {
+                                LiveCodingManualView()
+                                    .edgesIgnoringSafeArea(.all)
+                            } else {
+                                WaveformView(samples: audio.waveformBuffer)
+                                    .opacity(0.25)
+                                    .edgesIgnoringSafeArea(.all)
+                            }
 
                             TouchPad(
                                 x: $audio.variableX,
@@ -134,7 +140,13 @@ struct ContentView: View {
             case .help: HelpPanel()
             case .settings: SettingsPanel()
             case .midi: MIDIPanel()
-            case .performance: PerformancePanel()
+            case .performance: EmptyView()
+            }
+        }
+        .onChange(of: activePanel) { panel in
+            if panel == .performance {
+                showLiveManual.toggle()
+                activePanel = nil
             }
         }
     }

--- a/BitBeatSynth/LiveCodingManualView.swift
+++ b/BitBeatSynth/LiveCodingManualView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct LiveCodingManualView: View {
+    private let text: String
+
+    init() {
+        if let url = Bundle.main.url(forResource: "livecoding", withExtension: "txt"),
+           let contents = try? String(contentsOf: url) {
+            self.text = contents
+        } else {
+            self.text = "Live coding manual not available."
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            Text(text)
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.white)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.black.opacity(0.15))
+        .cornerRadius(8)
+    }
+}

--- a/BitBeatSynth/SidebarMenu.swift
+++ b/BitBeatSynth/SidebarMenu.swift
@@ -28,7 +28,7 @@ struct SidebarMenu: View {
             case .help: return "Help"
             case .settings: return "Settings"
             case .midi: return "MIDI"
-            case .performance: return "Live"
+            case .performance: return "Live Coding Mode"
             }
         }
     }


### PR DESCRIPTION
## Summary
- show a Live Coding Manual when selecting **Live Coding Mode**
- swap between waveform and manual without blocking the DualTouchpad
- label the sidebar button "Live Coding Mode"

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_683f53f3120883309bab07c3634b13e8