### PR TITLE
Fix JS error print strings

### DIFF
--- a/BitBeatSynth/BytebeatCompiler.swift
+++ b/BitBeatSynth/BytebeatCompiler.swift
@@ -5,7 +5,7 @@ struct BytebeatCompiler {
     static let context: JSContext = {
         let ctx = JSContext()!
         ctx.exceptionHandler = { ctx, err in
-            print("JS Error: \(err?.toString() ?? \"unknown\")")
+            print("JS Error: \(err?.toString() ?? "unknown")")
         }
         return ctx
     }()
@@ -18,7 +18,7 @@ struct BytebeatCompiler {
         // Capture errors for this compile
         ctx.exceptionHandler = { _, error in
             latestError = error?.toString()
-            print("JS Error: \(latestError ?? \"unknown\")")
+            print("JS Error: \(latestError ?? "unknown")")
         }
 
         let expr = expression.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/BitBeatSynth/LiveCodingManualView.swift
+++ b/BitBeatSynth/LiveCodingManualView.swift
@@ -20,6 +20,7 @@ struct LiveCodingManualView: View {
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(.leading, 80)
         .background(Color.black.opacity(0.15))
         .cornerRadius(8)
     }


### PR DESCRIPTION
## Summary
- correct quoting inside `BytebeatCompiler` error prints
- move manual content right with a left padding so it doesn't clash with the sidebar

## Testing
- `swiftc BitBeatSynth/BytebeatCompiler.swift -o /tmp/testbin` *(fails: no such module 'JavaScriptCore')*
- `swiftc BitBeatSynth/LiveCodingManualView.swift -o /tmp/testbin` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6840b3b2117083308e31ae1ab5361c26